### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -36,7 +36,7 @@ class syntax_plugin_header3 extends DokuWiki_Syntax_Plugin {
   /**
    * Handle the match
    */
-  function handle($match, $state, $pos, &$handler){
+  function handle($match, $state, $pos, Doku_Handler $handler){
     switch ($state) {
       case DOKU_LEXER_ENTER :
         $this->h_level = 7 - strspn($match,"=");
@@ -63,7 +63,7 @@ class syntax_plugin_header3 extends DokuWiki_Syntax_Plugin {
   /**
    * Create output
    */
-  function render($format, &$renderer, $data) {
+  function render($format, Doku_Renderer $renderer, $data) {
     list($state,$level,$pos) = $data;
     switch ($state) {
       case DOKU_LEXER_ENTER :


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
